### PR TITLE
Add writing of training data for convolutional network to TF-Record

### DIFF
--- a/LUCAS/notebooks/yelp/prep_conv_network_data.ipynb
+++ b/LUCAS/notebooks/yelp/prep_conv_network_data.ipynb
@@ -337,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -378,18 +378,12 @@
     "for training_vectors_slice, training_reviewers_slice, training_labels_slice in zip(split_training_vectors,\n",
     "                                                                                   split_training_reviewers,\n",
     "                                                                                   split_training_labels):\n",
-    "    filename = 'conv-' + str(max_review_words) + '-' + str(split) + '.tfrecord'\n",
+    "    filename = 'TEST-' + str(max_review_words) + '-' + str(split) + '.tfrecord'\n",
     "    split += 1\n",
     "    print(\"Writing file\", filename)\n",
     "    with tf.python_io.TFRecordWriter(filename) as writer:\n",
     "        for (vectors, reviewer, label) in zip(training_vectors_slice, training_reviewers_slice, training_labels_slice):\n",
-    "            vector = vectors.reshape(-1)\n",
-    "            vector_f = tf.train.Feature(float_list=tf.train.FloatList(value=vector))\n",
-    "            reviewer_f = tf.train.Feature(float_list=tf.train.FloatList(value=reviewer))\n",
-    "            labels_f = tf.train.Feature(int64_list=tf.train.Int64List(value=label))\n",
-    "\n",
-    "            features = { 'feature': vector_f, 'reviewer': reviewer_f, 'label': labels_f }\n",
-    "            tf_example = tf.train.Example(features=tf.train.Features(feature=features))\n",
+    "            tf_example = encode_example(vectors, reviewer, label)\n",
     "            writer.write(tf_example.SerializeToString())"
    ]
   },
@@ -414,7 +408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
The notebook that writes TF-Record data for the convolutional network to perform cross validation separates some data to use as a test set. This data was never written, but this PR adds the code that writes that so that after tweaking the Convolutional Network can be assessed on unseen data.