### PR TITLE
Add script for computing better reviewer features

### DIFF
--- a/LUCAS/scripts/feature_extraction.py
+++ b/LUCAS/scripts/feature_extraction.py
@@ -44,4 +44,8 @@ def scaled_reviewer_features(reviewset, entire_reviewset):
   reviewer_predictors = [list(reviewer_features(x.user_id, reviewer_reviews)) for x in reviewset]
   return StandardScaler().fit_transform(reviewer_predictors)
 
-
+def get_entire_dataset(yelpDataPath="../../data/yelpZip"):
+  review_set = review_set_pb2.ReviewSet()
+  with open(yelpDataPath, 'rb') as f:
+    review_set.ParseFromString(f.read())
+  return [x for x in review_set.reviews]


### PR DESCRIPTION
The existing method of computing user features would use only the balanced dataset that we would output features for. This version takes two datasets, the dataset we want to output features for and the dataset representing all known samples, even those outside the balanced dataset