### PR TITLE
Add method of limiting dataset to reviews with a max word length

### DIFF
--- a/LUCAS/scripts/feature_extraction.py
+++ b/LUCAS/scripts/feature_extraction.py
@@ -72,7 +72,7 @@ def get_balanced_dataset(yelpDataPath="../../data/yelpZip", max_seq_len=320):
 
   genuine_reviews = []
   counter_genuine = 0
-  for review in review_set.reviews:
+  for review in shuffle(review_set.reviews, random_state=1337):
     if review.label == True:
       continue
     if counter_genuine >= count_fake:


### PR DESCRIPTION
Since some of our models require a max review length due to memory constraints, this PR adds a function to the `feature_extraction.py` script that allows us to specify the max sequence length of the dataset we read. We should obtain benchmarks using the same dataset, so we should filter out the same reviews even for those experiments that do not have memory constraints